### PR TITLE
Add filter to optionally disable all tracking

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -281,7 +281,7 @@ class WC_Google_Analytics extends WC_Integration {
 		global $wp;
 		$display_ecommerce_tracking = false;
 
-		if ( is_admin() || current_user_can( 'manage_options' ) || ! $this->ga_id ) {
+		if ( $this->disable_tracking( 'all' ) ) {
 			return;
 		}
 
@@ -345,7 +345,7 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @return bool True if tracking for a certain setting is disabled
 	 */
 	private function disable_tracking( $type ) {
-		if ( is_admin() || current_user_can( 'manage_options' ) || ( ! $this->ga_id ) || 'no' === $type ) {
+		if ( is_admin() || current_user_can( 'manage_options' ) || ( ! $this->ga_id ) || 'no' === $type || apply_filters( 'woocommerce_ga_disable_tracking', false ) ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
This adds a simple filter to the `disable_tracking` method and then removes some duplicate code in the `tracking_code_display` method to make it work. Feedback is welcome.

#### Changes proposed in this Pull Request:
- Add filter to allow other plugins to disable tracking on demand.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? Make sure you ran `grunt` before creating this Pull Request.

